### PR TITLE
Remove config files from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='enigma2-plugin-extensions-foreca',
       packages=[pkg],
       package_dir={pkg: 'plugin'},
       package_data={pkg: ['*.png', '*.txt', '*.xml', '*/*.png', '*/*.txt', 'locale/*/LC_MESSAGES/*.mo']},
-      data_files=[('/etc/enigma2/Foreca', ['plugin/City.cfg', 'plugin/Filter.cfg', 'plugin/fav1.cfg', 'plugin/fav2.cfg', 'plugin/startservice.cfg'])],
+      data_files=[('/etc/enigma2/Foreca', ['plugin/City.cfg', 'plugin/Filter.cfg'])],
       cmdclass=setup_translate.cmdclass,  # for translation
       )


### PR DESCRIPTION
Fix build.

copying plugin/Filter.cfg -> /home/hains/openpli-oe-core/build/tmp/work/cortexa15hf-neon-vfpv4-oe-linux-gnueabi/ enigma2-plugin-extensions-foreca/git/image/etc/enigma2/Foreca | error: can't copy 'plugin/fav1.cfg': doesn't exist or not a regular file